### PR TITLE
Added width to elastic strap and formatting nit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ To purchase, go to https://store.glia.org
 * 1 buckle (buckle.stl)
 
 ## Other hardware
-* Elastic strap (70cm)
-* 28cm x 25cm x 0.125mm clear plastic sheet such as Mylar (facesheet.svg)
+* 70cm x 1cm Elastic strap
+* 28cm x 25cm x 0.125mm Clear plastic sheet such as Mylar (facesheet.svg)
 
 # Print instructions
 * Use PETG or ABS


### PR DESCRIPTION
Added width to strap dimensions and aligned formatting with plastic sheet dimensions. Actual width allowed in the buckle is 11.3mm, rounded down to 10mm/1cm for simplicity and spacing.