### PR TITLE
add a reference to an acceptable mil value for the mylar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To purchase, go to https://store.glia.org
 
 ## Other hardware
 * Elastic strap (70cm)
-* 28cm x 25cm x 0.125mm clear plastic sheet such as Mylar (facesheet.svg)
+* 28cm x 25cm x 0.125mm (5mil or greater) clear plastic sheet such as Mylar (facesheet.svg)
 
 # Print instructions
 * Use PETG or ABS


### PR DESCRIPTION
mylar is often sold using mils to denote thickness; 5mil is .127mm